### PR TITLE
Add AGENTS.md for Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a personal portfolio site (tomasreimers.com) built with **Next.js 16**, **React Three Fiber** (3D starfield), and **SCSS modules**. It is a purely static frontend — no backend, no database, no API, no auth.
+
+### Key commands
+
+See `package.json` scripts:
+- `yarn dev` — starts the Next.js dev server on port 3000
+- `yarn build` — static export to `dist/`
+
+### Caveats
+
+- **Lint**: `yarn lint` invokes `next lint`, which was removed in Next.js 16. There is no standalone ESLint config file in the repo, so linting is effectively unavailable.
+- **Tests**: No test framework or test scripts are configured.
+- **Peer-dependency warnings**: `yarn install` emits many peer-dep warnings from `@react-three/*` packages (missing `three`, React 19 mismatch). These are harmless; the app builds and runs fine.
+- **Static export**: `next.config.js` sets `output: "export"`, so `yarn start` (production SSR) won't work. Use `yarn dev` for development.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development instructions for this Next.js 16 portfolio site.

### What's included

- Key development commands (`yarn dev`, `yarn build`)
- Known caveats: `yarn lint` is broken (Next.js 16 removed `next lint` and no standalone ESLint config exists), no test framework configured, peer-dependency warnings from `@react-three/*` are harmless
- Note that `yarn start` won't work due to static export config — use `yarn dev` for development

### Environment verification

- `yarn install` — dependencies install successfully
- `yarn build` — static export compiles without errors
- `yarn dev` — dev server starts on port 3000, page renders with 3D starfield, bio, and links

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6a8ec1b-e1f9-4d2b-bf10-195ea74c986d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6a8ec1b-e1f9-4d2b-bf10-195ea74c986d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

